### PR TITLE
Fix: Add email validation to login and register screens

### DIFF
--- a/app/src/main/java/com/example/cmput301_app/MainActivity.java
+++ b/app/src/main/java/com/example/cmput301_app/MainActivity.java
@@ -71,6 +71,12 @@ public class MainActivity extends AppCompatActivity {
                 return;
             }
 
+            // checks if inputted email address is in proper format
+            if (!android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+                Toast.makeText(this, "Please enter a valid email address", Toast.LENGTH_SHORT).show();
+                return;
+            }
+
             btnLogin.setEnabled(false);
             mAuth.signInWithEmailAndPassword(email, password)
                     .addOnCompleteListener(this, task -> {

--- a/app/src/main/java/com/example/cmput301_app/RegisterActivity.java
+++ b/app/src/main/java/com/example/cmput301_app/RegisterActivity.java
@@ -70,6 +70,13 @@ public class RegisterActivity extends AppCompatActivity {
                 Toast.makeText(this, "Please fill all fields", Toast.LENGTH_SHORT).show();
                 return;
             }
+
+            // checks if inputted email address is in proper format
+            if (!android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+                Toast.makeText(this, "Please enter a valid email address", Toast.LENGTH_SHORT).show();
+                return;
+            }
+
             if (password.length() < 6) {
                 Toast.makeText(this, "Password must be at least 6 characters", Toast.LENGTH_SHORT).show();
                 return;


### PR DESCRIPTION
Added email format validation to both RegisterActivity and MainActivity 
using android.util.Patterns.EMAIL_ADDRESS to prevent invalid email inputs 
from being submitted.
[issue fix](https://github.com/CMPUT301W26glitch0/glitch0-events/issues/51)